### PR TITLE
Fix undefined array key warning when iframe parameters are omitted and add Chinese language support

### DIFF
--- a/lang/zh/settings.php
+++ b/lang/zh/settings.php
@@ -1,0 +1,10 @@
+<?php
+/**
+ * Chinese language file
+ *
+ * @license    GPL 2 (http://www.gnu.org/licenses/gpl.html)
+ * @author     doge24190 <me@doge24190.top>
+ */
+ 
+// for the configuration manager
+$lang['js_ok']  = '允许含有javascript的url链接';

--- a/plugin.info.txt
+++ b/plugin.info.txt
@@ -1,7 +1,7 @@
 base   iframe
 author Christopher Smith
 email  chris@jalakai.co.uk
-date   2023-08-17
+date   2026-05-22
 name   iframe plugin
 desc   Allows external URLs to be loaded into an iframe in your DokuWiki page.
 url    http://www.dokuwiki.org/plugin:iframe

--- a/syntax.php
+++ b/syntax.php
@@ -23,7 +23,7 @@ class syntax_plugin_iframe extends DokuWiki_Syntax_Plugin {
     function handle($match, $state, $pos, Doku_Handler $handler){
         $match = substr($match, 6, -2);
         list($url, $alt)   = array_pad(explode('|',$match,2), 2, null);
-        list($url, $param) = explode(' ',$url,2);
+        list($url, $param) = array_pad(explode(' ',$url,2), 2, '');
 
         // javascript pseudo uris allowed?
         if (!$this->getConf('js_ok') && substr($url,0,11) == 'javascript:'){


### PR DESCRIPTION
### 1. Fixes [#20.](https://github.com/Chris--S/dokuwiki-plugin-iframe/issues/20)

When using iframe syntax without optional parameters, for example:

`{{url>https://example.com}}`

explode(' ', $url, 2) returns only one element. Assigning it to
list($url, $param) triggers an "Undefined array key 1" warning on PHP 8.x.

This change pads the exploded array with an empty string so $param defaults
to the expected "no parameters" value.

###  2. Add Chinese language support